### PR TITLE
end-run around env vars issue

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,7 +21,7 @@ set :branch, ENV['REVISION'] || ENV['BRANCH'] || 'master'
 # set :pty, true
 
 # Default value for :linked_files is []
-append :linked_files, "config/blacklight.yml", "config/database.yml", "config/fedora.yml", "config/role_map.yml", "config/secrets.yml", "config/solr.yml"
+append :linked_files, "config/analytics.yml", "config/blacklight.yml", "config/browse_everything_providers.yml", "config/database.yml", "config/fedora.yml", "config/role_map.yml", "config/secrets.yml", "config/solr.yml"
 
 # Default value for linked_dirs is []
 append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"


### PR DESCRIPTION
For some reason, the env vars approach isn't working on the sandbox. But linking the config via capistrano works, so let's use that for now at least.