### PR TITLE
Disable realtime notifications

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -1,0 +1,2 @@
+realtime_notifications:
+  enabled: false


### PR DESCRIPTION
Ultimately we will want to re-enable this feature so we can test it. In the meantime, disable it because the current deployment configuration of Nurax is broken with realtime notifications enabled.

Refs samvera/hyrax#1700