### PR TITLE
changes fqdn of sandbox server

### DIFF
--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -2,5 +2,5 @@
 set :stage, :sandbox
 set :rails_env, 'production'
 set :deploy_to, '/opt/nurax'
-server 'demo.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
+server 'nurax.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
 

--- a/config/deploy/travis.rb
+++ b/config/deploy/travis.rb
@@ -2,6 +2,6 @@
 set :stage, :travis
 set :rails_env, 'production'
 set :deploy_to, '/opt/nurax'
-server 'demo.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
+server 'nurax.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
 set :ssh_options, keys: ['config/nurax-travis']
 


### PR DESCRIPTION
Moving the shared box over to nurax.curationexperts.com - for the time being, demo.curationexperts.com will still work - it will redirect to the new Nurax box, so everyone has some time to get used to the change.