### PR TITLE
Add cjcolvar to admin group

### DIFF
--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -16,6 +16,7 @@ development:
     - tom@curationexperts.com
     - jamie@curationexperts.com
     - valerie@curationexperts.com
+    - cjcolvar@indiana.edu
 production:
   admin:
     - mjgiarlo@stanford.edu
@@ -35,6 +36,7 @@ production:
     - tom@curationexperts.com
     - jamie@curationexperts.com
     - valerie@curationexperts.com
+    - cjcolvar@indiana.edu
 test:
   archivist:
     - archivist1@example.com


### PR DESCRIPTION
I need to do a gap analysis for work on Avalon 7 so I need admin access to fully test out the system.