### PR TITLE
Add missing migrations from hyrax 

### DIFF
--- a/db/migrate/20180301145056_add_collection_type_sharing_options.hyrax.rb
+++ b/db/migrate/20180301145056_add_collection_type_sharing_options.hyrax.rb
@@ -1,0 +1,5 @@
+class AddCollectionTypeSharingOptions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :hyrax_collection_types, :share_applies_to_new_works, :boolean, null: false, default: true
+  end
+end

--- a/db/migrate/20180301145057_add_unique_constraint_to_permission_template_accesses.hyrax.rb
+++ b/db/migrate/20180301145057_add_unique_constraint_to_permission_template_accesses.hyrax.rb
@@ -1,0 +1,8 @@
+class AddUniqueConstraintToPermissionTemplateAccesses < ActiveRecord::Migration[5.1]
+  def change
+    add_index :permission_template_accesses,
+              [:permission_template_id, :agent_id, :agent_type, :access],
+              unique: true,
+              name: 'uk_permission_template_accesses'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180201145627) do
+ActiveRecord::Schema.define(version: 20180301145057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This PR skips `rename_admin_set_id_to_source_id.hyrax.rb` since it duplicates an existing nurax migration that doesn't exist in hyrax: `20171120193255_add_source_type_to_permission_templates.hyrax.rb`.

This PR allows me to spin up nurax locally to test bugs and work on fixes.