### PR TITLE
Restart sidekiq via system service

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,3 +34,27 @@ append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/syst
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
+
+# We have to re-define capistrano-sidekiq's tasks to work with
+# systemctl in production. Note that you must clear the previously-defined
+# tasks before re-defining them.
+Rake::Task["sidekiq:stop"].clear_actions
+Rake::Task["sidekiq:start"].clear_actions
+Rake::Task["sidekiq:restart"].clear_actions
+namespace :sidekiq do
+  task :stop do
+    on roles(:app) do
+      execute :sudo, :systemctl, :stop, :sidekiq
+    end
+  end
+  task :start do
+    on roles(:app) do
+      execute :sudo, :systemctl, :start, :sidekiq
+    end
+  end
+  task :restart do
+    on roles(:app) do
+      execute :sudo, :systemctl, :restart, :sidekiq
+    end
+  end
+end

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -2,5 +2,4 @@
 set :stage, :sandbox
 set :rails_env, 'production'
 set :deploy_to, '/opt/nurax'
-server 'nurax.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
-
+server 'nurax.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/travis.rb
+++ b/config/deploy/travis.rb
@@ -2,6 +2,5 @@
 set :stage, :travis
 set :rails_env, 'production'
 set :deploy_to, '/opt/nurax'
-server 'nurax.curationexperts.com', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
+server 'nurax.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]
 set :ssh_options, keys: ['config/nurax-travis']
-


### PR DESCRIPTION
When sidekiq is only restarted via a capisratno deploy
it doesn't come back up after a system reboot.
For production services, we are changing our setup so
that sidekiq runs as a systemctl service. This means
capistrano must be updated to stop and start sidekiq
via a systemctl command.