### PR TITLE
Configure Skylight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'honeybadger', '~> 3.1'
+gem 'skylight',    '~> 2.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.2'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -728,6 +728,10 @@ GEM
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
+    skylight (2.0.1)
+      skylight-core (= 2.0.1)
+    skylight-core (2.0.1)
+      activesupport (>= 4.2.0)
     slop (4.6.2)
     solr_wrapper (1.2.0)
       faraday
@@ -844,6 +848,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq
+  skylight (~> 2.0)
   solr_wrapper (>= 0.3)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,3 @@
+---
+# The authentication token for the application.
+authentication: ANeuToXJ21ZlD33CWpJOSNcRDVceqSKppfLaZdxeEZc


### PR DESCRIPTION
Setup `skylight` according to the instructions at
https://www.skylight.io/support/getting-started.

Nurax will have a free oss.skylight.io account, in support of understanding
Hyrax performance and bottlenecks.

The Skylight setup instructions are fairly clear that the token should be
checked into public source control. I'm not exactly sure how this works, but I'm
trusting it.