### PR TITLE
update to hyrax 2.1.0.rc4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,8 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 #gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'hyrax', github: 'samvera/hyrax', branch: 'v2.1.0.rc3_qa'
-# gem 'hyrax', '2.1.0.rc3'
+# gem 'hyrax', github: 'samvera/hyrax', branch: 'v2.1.0.rc3_qa'
+gem 'hyrax', '2.1.0.rc4'
 gem 'devise'
 gem 'devise-i18n'
 gem 'devise-guests', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,56 +1,3 @@
-GIT
-  remote: https://github.com/samvera/hyrax.git
-  revision: bd659185daa7d5bd1a49ec766a13242945dc0ccd
-  branch: v2.1.0.rc3_qa
-  specs:
-    hyrax (2.1.0.rc3)
-      active-fedora (~> 11.5, >= 11.5.2)
-      almond-rails (~> 0.1)
-      awesome_nested_set (~> 3.1)
-      blacklight (~> 6.14)
-      blacklight-gallery (~> 0.7)
-      breadcrumbs_on_rails (~> 3.0)
-      browse-everything (>= 0.10.5)
-      carrierwave (~> 1.0)
-      clipboard-rails (~> 1.5)
-      dry-equalizer (~> 0.2)
-      dry-struct (~> 0.1)
-      dry-validation (~> 0.9)
-      flipflop (~> 2.3)
-      flot-rails (~> 0.0.6)
-      font-awesome-rails (~> 4.2)
-      hydra-derivatives (~> 3.3)
-      hydra-editor (>= 3.3, < 5.0)
-      hydra-head (>= 10.5.0)
-      hydra-works (~> 0.16)
-      iiif_manifest (>= 0.3, < 0.5)
-      jquery-datatables-rails (~> 3.4)
-      jquery-ui-rails (~> 6.0)
-      json-schema
-      kaminari_route_prefix (~> 0.1.1)
-      legato (~> 0.3)
-      linkeddata
-      mailboxer (~> 0.12)
-      nest (~> 3.1)
-      noid-rails (~> 3.0.0)
-      oauth
-      oauth2 (~> 1.2)
-      posix-spawn
-      power_converter (~> 0.1, >= 0.1.2)
-      pul_uv_rails (~> 2.0)
-      qa (~> 2.0)
-      rails (~> 5.0)
-      rails_autolink (~> 1.1)
-      rdf-rdfxml
-      redis-namespace (~> 1.5)
-      redlock (>= 0.1.2)
-      retriable (>= 2.9, < 4.0)
-      samvera-nesting_indexer (~> 2.0)
-      select2-rails (~> 3.5)
-      signet
-      simple_form (~> 3.2, <= 3.5.0)
-      tinymce-rails (~> 4.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -121,12 +68,12 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.5.0)
+    autoprefixer-rails (8.5.2)
       execjs
     awesome_nested_set (3.1.4)
       activerecord (>= 4.0.0, < 5.3)
     aws-eventstream (1.0.0)
-    aws-partitions (1.87.0)
+    aws-partitions (1.88.0)
     aws-sdk-core (3.21.2)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
@@ -321,15 +268,15 @@ GEM
       railties (>= 3.2, < 6.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.21.2)
+    google-api-client (0.22.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
       mime-types (~> 3.0)
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
-    google_drive (2.1.11)
-      google-api-client (>= 0.11.0, < 0.22.0)
+    google_drive (2.1.3)
+      google-api-client (>= 0.11.0, < 1.0.0)
       googleauth (>= 0.5.0, < 1.0.0)
       nokogiri (>= 1.5.3, < 2.0.0)
     googleauth (0.6.2)
@@ -391,6 +338,53 @@ GEM
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.9)
       om (~> 3.1)
+    hyrax (2.1.0.rc4)
+      active-fedora (~> 11.5, >= 11.5.2)
+      almond-rails (~> 0.1)
+      awesome_nested_set (~> 3.1)
+      blacklight (~> 6.14)
+      blacklight-gallery (~> 0.7)
+      breadcrumbs_on_rails (~> 3.0)
+      browse-everything (>= 0.10.5)
+      carrierwave (~> 1.0)
+      clipboard-rails (~> 1.5)
+      dry-equalizer (~> 0.2)
+      dry-struct (~> 0.1)
+      dry-validation (~> 0.9)
+      flipflop (~> 2.3)
+      flot-rails (~> 0.0.6)
+      font-awesome-rails (~> 4.2)
+      hydra-derivatives (~> 3.3)
+      hydra-editor (>= 3.3, < 5.0)
+      hydra-head (>= 10.5.0)
+      hydra-works (~> 0.16)
+      iiif_manifest (>= 0.3, < 0.5)
+      jquery-datatables-rails (~> 3.4)
+      jquery-ui-rails (~> 6.0)
+      json-schema
+      kaminari_route_prefix (~> 0.1.1)
+      legato (~> 0.3)
+      linkeddata
+      mailboxer (~> 0.12)
+      nest (~> 3.1)
+      noid-rails (~> 3.0.0)
+      oauth
+      oauth2 (~> 1.2)
+      posix-spawn
+      power_converter (~> 0.1, >= 0.1.2)
+      pul_uv_rails (~> 2.0)
+      qa (~> 2.0)
+      rails (~> 5.0)
+      rails_autolink (~> 1.1)
+      rdf-rdfxml
+      redis-namespace (~> 1.5)
+      redlock (>= 0.1.2)
+      retriable (>= 2.9, < 4.0)
+      samvera-nesting_indexer (~> 2.0)
+      select2-rails (~> 3.5)
+      signet
+      simple_form (~> 3.2, <= 3.5.0)
+      tinymce-rails (~> 4.1)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -839,7 +833,7 @@ DEPENDENCIES
   factory_girl_rails
   fcrepo_wrapper
   honeybadger (~> 3.1)
-  hyrax!
+  hyrax (= 2.1.0.rc4)
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5, < 3.2)


### PR DESCRIPTION
PRs since in rc4 not in rc3_bugfixes…
* PR #3102 - Switch to using member_of_collection_ids_ssim to power collection facet
* PR #3100 - Make work item rows shown configurable
* PR #3097 - Reinstate the `create_work_presenter` and deprecate it

PRs since rc3 in rc3_bugfixes...
* PR #3070 - Avoid call to solr when calling #parent after the first time
* PR #3080 - Move permissions inheriting earlier in block before other jobs are enqueued...
* PR #3077 - Ensure locale is preserved when following links with urls generated outside of controller context.
* PR #3089 - remove ability to bulk add works to a new collection
* PR #3094 - Visibility component close collapsable only inside save widget on page load
* PR #3091 - Add work item pagination