### PR TITLE
Use cron job to auto-update hyrax and auto-deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ before_install:
 - gem install bundler
 - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222
   http://localhost &
-after_success:
-  - openssl aes-256-cbc -K $encrypted_a9d30a8f0000_key -iv $encrypted_a9d30a8f0000_iv -in nurax-dev-deploy_rsa.enc -out nurax-dev-deploy_rsa -d
-  - bundle exec cap nurax-dev deploy
 jdk:
 - oraclejdk8
 env:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@ and is deployed much less often, only when there has been a new release, to
 The nurax servers are built using the [ansible-samvera](https://github.com/curationexperts/ansible-samvera) ansible roles. These servers are maintained by Data Curation Experts as a service to [the Samvera Community](http://samvera.org).
 
 ## Auto-deploy process
-The method we use to auto-deploy is documented in [the DCE Playbook](https://curationexperts.github.io/playbook/production/continuous_deployment.html). Auto-deploy to `samvera-dev` will happen upon a successful travis build of the `nurax` codebase. This happens whenever a PR is merged to master, and is triggered by travis once per day if no PR is submitted that day. Eventually we would like to have this code deploy every time a successful PR is made to Hyrax.
+There is a cron-job on `nurax-dev` running this script once per day:
+```
+#!/usr/local/bin/ruby
+
+# Get the latest nurax master
+# Make a branch with today's date and update hyrax
+# Push and deploy that branch
+# Delete the branch
+
+today = Time.now.strftime('%Y-%m-%e-%H-%M')
+`cd /home/ubuntu/nurax; git checkout master; git pull; git checkout -b "#{today}"`
+`cd /home/ubuntu/nurax; bundle update hyrax`
+`cd /home/ubuntu/nurax; git commit -a -m 'Daily update for "#{today}"'; git push --set-upstream origin #{today}`
+`cd /home/ubuntu/nurax; BRANCH_NAME="#{today}" cap nurax-dev deploy`
+`cd /home/ubuntu/nurax; git checkout master; git branch -d "#{today}"; git push origin --delete "${today}"`
+```
 
 ## Questions
 Please direct questions about this code or the servers where it runs to the `#nurax` channel on Samvera slack.


### PR DESCRIPTION
Remove cd deploy from travis build
Instead, use a cron job (documented in README)
to update the version of hyrax daily and deploy
an updated branch.