### PR TITLE
Upgrade rubyzip to address CVE-2018-1000544

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.2'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
+gem "rubyzip", ">= 1.2.2"
 
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -698,7 +698,7 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.10.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.5.7)
@@ -852,6 +852,7 @@ DEPENDENCIES
   riiif (~> 1.1)
   rsolr (~> 2.0)
   rspec-rails
+  rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2018-1000544 for more details.