### PR TITLE
fixes solr volume persistence for solr6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 volumes:
   db-dev:
   fcrepo-dev:
-  solr:
+  solr-dev:
   redis-dev:
   bundled:
 
@@ -120,11 +120,11 @@ services:
       - 8983
     networks:
       internal:
-    volumes:
-      - ./solr/config:/opt/solr/nurax_conf
-      - solr:/opt/solr/server/mycores
   solr-dev:
     <<: *solr
+    volumes:
+      - ./solr/config:/opt/solr/nurax_conf
+      - solr-dev:/opt/solr/server/solr/mycores
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate
@@ -132,6 +132,8 @@ services:
       - /opt/solr/nurax_conf
   solr-test:
     <<: *solr
+    volumes:
+      - ./solr/config:/opt/solr/nurax_conf
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate


### PR DESCRIPTION
We found a bug in the volume persistence between restarts of the application that was related to the path that SOLR 6.x expects for cores. Also, this PR removes volume persistence for SOLR in the test environment (which really isn't necessary and wastes local disk space).