### PR TITLE
fixes docker-compose solr configuration path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
   solr-dev:
     <<: *solr
     volumes:
-      - ./solr/config:/opt/solr/nurax_conf
+      - ./solr/conf:/opt/solr/nurax_conf
       - solr-dev:/opt/solr/server/solr/mycores
     entrypoint:
       - docker-entrypoint.sh
@@ -133,7 +133,7 @@ services:
   solr-test:
     <<: *solr
     volumes:
-      - ./solr/config:/opt/solr/nurax_conf
+      - ./solr/conf:/opt/solr/nurax_conf
     entrypoint:
       - docker-entrypoint.sh
       - solr-precreate


### PR DESCRIPTION
I was doing some work locally and just ran into the solr configuration directory change needed for docker-compose.yml.