### PR TITLE
Updating deploy to use `main` instead of `master`

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :rails_env, 'production'
 set :ssh_options, keys: ['nurax-dev-deploy_rsa'] if File.exist?('nurax-dev-deploy_rsa')
 
 # Default branch is :master
-set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'master'
+set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'main'
 
 # Default deploy_to directory is /var/www/my_app_name
 # set :deploy_to, "/var/www/my_app_name"


### PR DESCRIPTION
On or around 2021-04-20, Hyrax renamed the default branch from `master` to `main`.  I suspect this will get deploying new changes unstuck.