### PR TITLE
change some more `master` references to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # README
 
 This is an application used for testing the state of [Hyrax](https://github.com/samvera/hyrax). The `master` branch is pinned to Hyrax
-master, and is automatically deployed to [nurax-dev.curationexperts.com](https://nurax-dev.curationexperts.com) once per
+`main`, and is automatically deployed to [nurax-dev.curationexperts.com](https://nurax-dev.curationexperts.com) once per
 day. The `nurax-stable` branch is pinned to the latest stable release of Hyrax,
 and is deployed much less often, only when there has been a new release, to
 [nurax-stable.curationexperts.com](https://nurax-stable.curationexperts.com).

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,7 +7,7 @@ set :deploy_to, '/opt/nurax'
 set :rails_env, 'production'
 set :ssh_options, keys: ['nurax-dev-deploy_rsa'] if File.exist?('nurax-dev-deploy_rsa')
 
-# Default branch is :master
+# Default branch is :main
 set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'main'
 
 # Default deploy_to directory is /var/www/my_app_name


### PR DESCRIPTION
cleans up some more `master` references.

i think the actual issue that needs fixing may be an ENV in the deploy environment though?

https://github.com/curationexperts/nurax/compare/main-main?expand=1#diff-3d066bc83eaf220ed7d8276202a78415dfe66ddf285f3382273b86d5845ab9c4R11