### PR TITLE
Turn cron job into rake task run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,8 @@ workflows:
             - build:
                 name: testing
             - deploy-job:
+                requires:
+                    - testing
                 filters:
                   branches:
                     only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,9 @@ jobs:
             bundler_version:
                 type: string
                 default: 1.17.3
-        docker:
-            - image: circleci/ruby:2.6.3
+        executor:
+            name: samvera/ruby_fcrepo_solr_redis_postgres
+            ruby_version: << parameters.ruby_version >>
         working_directory: ~/project
         steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,21 @@ jobs:
             - samvera/bundle:
                 ruby_version: << parameters.ruby_version >>
                 bundler_version: << parameters.bundler_version >>
+
+            - run:
+                name: Get yarn version
+                command: echo $(yarn --version) >> "YARN_VERSION"
+
+            - restore_cache:
+                keys:
+                    - v1-yarn-{{ checksum "yarn.lock" }}-{{ checksum "YARN_VERSION" }}
+
+            - run: yarn
+
+            - save_cache:
+                key: v1-yarn-{{ checksum "yarn.lock" }}-{{ checksum "YARN_VERSION" }}
+                paths:
+                    - ~/project/node_modules
             - add_ssh_keys
             - run:
                   name: Use rake to deploy with latest Hyrax

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,5 +103,4 @@ workflows:
                 filters:
                   branches:
                     only:
-                      - nurax-dev_ci_deploy
                       - main # Only run deploy job when commit is on the main branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,19 +73,17 @@ jobs:
                 bundler_version: << parameters.bundler_version >>
             - add_ssh_keys
             - run:
-                  name: Deploy if tests pass and branch is main
-                  command: bundle exec cap nurax-dev deploy
-
+                  name: Use rake to deploy with latest Hyrax
+                  command: bundle exec rake cd:nurax_dev_deploy
 workflows:
     version: 2
     ci:
         jobs:
             - build:
                 name: testing
-            # - deploy-job:
-            #     requires:
-            #         - testing
-            #     filters:
-            #       branches:
-                    # only: add_circle_ci
-                    # only: main # Only run deploy job when commit is on the main branch
+            - deploy-job:
+                filters:
+                  branches:
+                    only:
+                      - nurax-dev_ci_deploy
+                      - main # Only run deploy job when commit is on the main branch

--- a/lib/tasks/continuous_deploy.rake
+++ b/lib/tasks/continuous_deploy.rake
@@ -1,0 +1,18 @@
+namespace :cd do
+  desc "Continuous deployment to Nurax environments"
+  task :nurax_dev_deploy do
+    # NOTE: If you run this job locally, at the end of it you will be on the main branch of the repo
+    # Get the latest nurax main
+    # Make a branch with today's date and update hyrax
+    # Push and deploy that branch
+    # Delete the branch
+
+    today = Time.now.strftime('%Y-%m-%e-%H-%M')
+    `git checkout main; git pull; git checkout -b "#{today}"`
+    `bundle update hyrax`
+    `git commit -a -m 'Daily update for "#{today}"'; git push --set-upstream origin #{today}`
+    `BRANCH_NAME="#{today}" cap nurax-dev deploy`
+    `git checkout main; git push origin --delete "#{today}"`
+    `git checkout main; git branch -D "#{today}"`
+  end
+end


### PR DESCRIPTION
See also PR on Hyrax - https://github.com/samvera/hyrax/pull/4966

On commits to hyrax/main, CircleCI for Hyrax will use an API call to trigger Nurax's CircleCI. Nurax's CI will run tests, and when they are successful, will deploy to the https://nurax-dev.curationexperts.com/ environment.