### PR TITLE
Conservative update of hydra-derivatives

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,9 +451,10 @@ GEM
     hydra-core (11.0.7)
       hydra-access-controls (= 11.0.7)
       railties (>= 4.0.0, < 6)
-    hydra-derivatives (3.6.0)
+    hydra-derivatives (3.6.1)
       active-fedora (>= 11.5.6, != 13.2.1, != 13.2.0, != 13.1.3, != 13.1.2, != 13.1.1, != 13.1.0, != 13.0.0, != 12.2.1, != 12.2.0, != 12.1.1, != 12.1.0, != 12.0.3, != 12.0.2, != 12.0.1, != 12.0.0)
       active_encode (~> 0.1)
+      activemodel (< 6.1)
       activesupport (>= 4.0, < 7)
       addressable (~> 2.5)
       deprecation
@@ -1025,4 +1026,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   2.2.30
+   2.3.6


### PR DESCRIPTION
The Hyrax Maintenance WG is attempting to test a solution for https://github.com/samvera/hyrax/issues/4971 and needs the hydra-derivatives gem to be updated on nurax.